### PR TITLE
reduce dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Hidden
 .*
+!/.gitignore
 !.gitkeep
 /data/
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ clean:
 
 install:
 	python -m pip install --upgrade pip setuptools wheel
+	pipx install "ruff<0.2" pip-tools
 	pip install -r requirements.txt
-	pipx install "ruff<0.2"
 
 fmt:
 	ruff check . --fix
@@ -29,5 +29,4 @@ verify_gh:
 verify:
 	ruff check .
 	ruff format . --check
-	pip-compile -q --all-extras
 	PYTHONDONTWRITEBYTECODE=1 pytest .

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ fmt:
 	ruff format .
 
 freeze:
-	pip-compile -qU --all-extras
+	pip-compile -qU --all-extras --no-strip-extras
 
 verify_gh:
 	ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "mapclassify",
     "pandas<2",
     "pyarrow",
+    "pydantic",
     "pyspark==3.3.2",
     "python-dotenv",
     "rich",
@@ -45,6 +46,8 @@ homepage = "https://github.com/Defra-Data-Science-Centre-of-Excellence/elmo-geo"
 [build-system]
 requires = ["setuptools>=64.0.0"]
 build-backend = "setuptools.build_meta"
+
+
 
 [tool.pytest.ini_options]
 python_files = "tests/*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,29 +5,18 @@ description = "Environmental Land Management Geospatial Analysis"
 readme = "README.md"
 dependencies = [
     "apache-sedona==1.4.1",
-    "beautifulsoup4",
     "contextily",
-    "databricks-cli",
-    "databricks-sdk",
-    "python-dotenv",
-    "esridump",
+    "databricks-sdk<0.21",
+    "folium",
     "geopandas",
     "mapclassify",
-    "numpy",
-    "osdatahub",
-    "osmnx",
-    "pandas<=1.5.3",
+    "pandas<2",
     "pyarrow",
-    "pydantic",
-    "pyogrio",
     "pyspark==3.3.2",
+    "python-dotenv",
     "rich",
-    "rasterio",
     "rioxarray",
     "seaborn",
-    "sentinelsat",
-    "shapely",
-    "xarray",
 ]
 requires-python = ">=3.10"
 
@@ -36,13 +25,17 @@ exclude = ["tests"]
 
 [project.optional-dependencies]
 dev = [
-    "ruff<=0.1.15",
+    "ruff<0.2",
     "pip-tools",
     "pytest",
-    "dbx",
-    "ipykernel",
-    "ipython",
-    "ipywidgets",
+]
+old = [
+    "beautifulsoup4",
+    "pyogrio",
+    "sentinelsat",
+    "osmnx",
+    "osdatahub",
+    "statsmodels",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,16 +25,16 @@ exclude = ["tests"]
 
 [project.optional-dependencies]
 dev = [
-    "ruff<0.2",
     "pip-tools",
     "pytest",
+    "ruff<0.2",
 ]
 old = [
     "beautifulsoup4",
-    "pyogrio",
-    "sentinelsat",
     "osmnx",
     "osdatahub",
+    "pyogrio",
+    "sentinelsat",
     "statsmodels",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,60 +6,40 @@
 #
 affine==2.4.0
     # via rasterio
-aiohttp==3.9.3
-    # via dbx
-aiosignal==1.3.1
-    # via aiohttp
 apache-sedona==1.4.1
     # via elmo_geo (pyproject.toml)
-arrow==1.3.0
-    # via cookiecutter
-asttokens==2.4.1
-    # via stack-data
-async-timeout==4.0.3
-    # via aiohttp
 attrs==23.2.0
     # via
-    #   aiohttp
     #   apache-sedona
     #   fiona
     #   rasterio
 beautifulsoup4==4.12.3
     # via elmo_geo (pyproject.toml)
-binaryornot==0.4.4
-    # via cookiecutter
-build==1.0.3
+branca==0.7.2
+    # via folium
+build==1.2.1
     # via pip-tools
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   fiona
     #   pyogrio
     #   pyproj
     #   rasterio
     #   requests
-cffi==1.16.0
-    # via cryptography
-chardet==5.2.0
-    # via binaryornot
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
     #   click-plugins
     #   cligj
-    #   cookiecutter
-    #   databricks-cli
-    #   dbx
     #   fiona
     #   geomet
     #   mercantile
-    #   mlflow-skinny
     #   pip-tools
     #   rasterio
     #   sentinelsat
-    #   typer
 click-plugins==1.1.1
     # via
     #   fiona
@@ -68,56 +48,22 @@ cligj==0.7.2
     # via
     #   fiona
     #   rasterio
-cloudpickle==3.0.0
-    # via mlflow-skinny
-colorama==0.4.6
-    # via typer
-comm==0.2.1
-    # via
-    #   ipykernel
-    #   ipywidgets
-commonmark==0.9.1
-    # via rich
-contextily==1.5.0
+contextily==1.6.0
     # via elmo_geo (pyproject.toml)
-contourpy==1.1.1
+contourpy==1.2.1
     # via matplotlib
-cookiecutter==2.5.0
-    # via dbx
-cryptography==41.0.7
-    # via dbx
 cycler==0.12.1
     # via matplotlib
-databricks-cli==0.17.8
-    # via
-    #   dbx
-    #   elmo_geo (pyproject.toml)
 databricks-sdk==0.20.0
     # via elmo_geo (pyproject.toml)
-dbx==0.8.18
-    # via elmo_geo (pyproject.toml)
-debugpy==1.8.1
-    # via ipykernel
-decorator==5.1.1
-    # via ipython
-entrypoints==0.4
-    # via mlflow-skinny
-esridump==1.13.0
-    # via elmo_geo (pyproject.toml)
-exceptiongroup==1.2.0
-    # via
-    #   ipython
-    #   pytest
-executing==2.0.1
-    # via stack-data
-fiona==1.9.5
+exceptiongroup==1.2.1
+    # via pytest
+fiona==1.9.6
     # via geopandas
-fonttools==4.49.0
+folium==0.16.0
+    # via elmo_geo (pyproject.toml)
+fonttools==4.53.0
     # via matplotlib
-frozenlist==1.4.1
-    # via
-    #   aiohttp
-    #   aiosignal
 geographiclib==2.0
     # via geopy
 geojson==3.0.1
@@ -126,91 +72,58 @@ geojson==3.0.1
     #   sentinelsat
 geomet==1.1.0
     # via sentinelsat
-geopandas==0.13.2
+geopandas==0.14.4
     # via
     #   elmo_geo (pyproject.toml)
     #   osmnx
 geopy==2.4.1
     # via contextily
-gitdb==4.0.11
-    # via gitpython
-gitpython==3.1.42
-    # via mlflow-skinny
-google-auth==2.28.0
+google-auth==2.29.0
     # via databricks-sdk
-html2text==2020.1.16
+html2text==2024.2.26
     # via sentinelsat
-idna==3.6
-    # via
-    #   requests
-    #   yarl
-importlib-metadata==7.0.1
-    # via mlflow-skinny
+idna==3.7
+    # via requests
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.2
-    # via elmo_geo (pyproject.toml)
-ipython==8.1.1
+jinja2==3.1.4
     # via
-    #   elmo_geo (pyproject.toml)
-    #   ipykernel
-    #   ipywidgets
-ipywidgets==8.1.2
-    # via elmo_geo (pyproject.toml)
-jedi==0.19.1
-    # via ipython
-jinja2==3.1.3
-    # via
-    #   cookiecutter
-    #   dbx
-joblib==1.3.2
+    #   branca
+    #   folium
+joblib==1.4.2
     # via
     #   contextily
     #   scikit-learn
-jupyter-client==8.6.0
-    # via ipykernel
-jupyter-core==5.7.1
-    # via
-    #   ipykernel
-    #   jupyter-client
-jupyterlab-widgets==3.0.10
-    # via ipywidgets
 kiwisolver==1.4.5
     # via matplotlib
-mapclassify==2.6.0
+mapclassify==2.6.1
     # via elmo_geo (pyproject.toml)
+markdown-it-py==3.0.0
+    # via rich
 markupsafe==2.1.5
     # via jinja2
-matplotlib==3.7.5
+matplotlib==3.9.0
     # via
     #   contextily
     #   seaborn
-matplotlib-inline==0.1.6
-    # via
-    #   ipykernel
-    #   ipython
+mdurl==0.1.2
+    # via markdown-it-py
 mercantile==1.2.1
     # via contextily
-mlflow-skinny==2.10.2
-    # via dbx
-multidict==6.0.5
-    # via
-    #   aiohttp
-    #   yarl
-nest-asyncio==1.6.0
-    # via ipykernel
-networkx==3.1
+networkx==3.3
     # via
     #   mapclassify
     #   osmnx
-numpy==1.24.4
+numpy==1.26.4
     # via
     #   contourpy
-    #   elmo_geo (pyproject.toml)
+    #   folium
+    #   geopandas
     #   mapclassify
     #   matplotlib
     #   osmnx
     #   pandas
+    #   patsy
     #   pyarrow
     #   pyogrio
     #   rasterio
@@ -220,23 +133,21 @@ numpy==1.24.4
     #   seaborn
     #   shapely
     #   snuggs
+    #   statsmodels
     #   xarray
-oauthlib==3.2.2
-    # via databricks-cli
-osdatahub==1.2.9
+osdatahub==1.2.10
     # via elmo_geo (pyproject.toml)
-osmnx==1.9.1
+osmnx==1.9.3
     # via elmo_geo (pyproject.toml)
-packaging==23.2
+packaging==24.0
     # via
     #   build
     #   geopandas
-    #   ipykernel
     #   matplotlib
-    #   mlflow-skinny
     #   pyogrio
     #   pytest
     #   rioxarray
+    #   statsmodels
     #   xarray
 pandas==1.5.3
     # via
@@ -245,224 +156,127 @@ pandas==1.5.3
     #   mapclassify
     #   osmnx
     #   seaborn
+    #   statsmodels
     #   xarray
-parso==0.8.3
-    # via jedi
-pathspec==0.12.1
-    # via dbx
-pexpect==4.9.0
-    # via ipython
-pillow==10.2.0
+patsy==0.5.6
+    # via statsmodels
+pillow==10.3.0
     # via
     #   contextily
     #   matplotlib
-pip-tools==7.4.0
+pip-tools==7.4.1
     # via elmo_geo (pyproject.toml)
-platformdirs==4.2.0
-    # via jupyter-core
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.43
-    # via ipython
-protobuf==4.25.3
-    # via mlflow-skinny
-psutil==5.9.8
-    # via ipykernel
-ptyprocess==0.7.0
-    # via pexpect
-pure-eval==0.2.2
-    # via stack-data
 py4j==0.10.9.5
     # via pyspark
-pyarrow==15.0.0
+pyarrow==16.1.0
     # via elmo_geo (pyproject.toml)
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via google-auth
-pycparser==2.21
-    # via cffi
-pydantic==1.10.14
-    # via
-    #   dbx
-    #   elmo_geo (pyproject.toml)
-pygments==2.17.2
-    # via
-    #   ipython
-    #   rich
-pyjwt==2.8.0
-    # via databricks-cli
-pyogrio==0.7.2
+pygments==2.18.0
+    # via rich
+pyogrio==0.8.0
     # via elmo_geo (pyproject.toml)
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via
     #   matplotlib
     #   snuggs
-pyproj==3.5.0
+pyproj==3.6.1
     # via
     #   geopandas
     #   rioxarray
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pyspark==3.3.2
     # via elmo_geo (pyproject.toml)
-pytest==8.0.1
+pytest==8.2.1
     # via elmo_geo (pyproject.toml)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
-    #   arrow
-    #   jupyter-client
     #   matplotlib
     #   pandas
 python-dotenv==1.0.1
     # via elmo_geo (pyproject.toml)
-python-slugify==8.0.4
-    # via cookiecutter
-pytz==2023.4
-    # via
-    #   mlflow-skinny
-    #   pandas
-pyyaml==6.0.1
-    # via
-    #   cookiecutter
-    #   dbx
-    #   mlflow-skinny
-pyzmq==25.1.2
-    # via
-    #   ipykernel
-    #   jupyter-client
-rasterio==1.3.9
+pytz==2024.1
+    # via pandas
+rasterio==1.3.10
     # via
     #   contextily
-    #   elmo_geo (pyproject.toml)
     #   rioxarray
 requests==2.31.0
     # via
     #   contextily
-    #   cookiecutter
-    #   databricks-cli
     #   databricks-sdk
-    #   dbx
-    #   esridump
-    #   mlflow-skinny
+    #   folium
     #   osdatahub
     #   osmnx
     #   sentinelsat
-rich==12.6.0
-    # via
-    #   cookiecutter
-    #   dbx
-    #   elmo_geo (pyproject.toml)
-    #   typer
-rioxarray==0.13.4
+rich==13.7.1
+    # via elmo_geo (pyproject.toml)
+rioxarray==0.15.5
     # via elmo_geo (pyproject.toml)
 rsa==4.9
     # via google-auth
 ruff==0.1.15
     # via elmo_geo (pyproject.toml)
-scikit-learn==1.3.2
+scikit-learn==1.5.0
     # via mapclassify
-scipy==1.10.1
+scipy==1.13.1
     # via
     #   mapclassify
     #   scikit-learn
+    #   statsmodels
 seaborn==0.13.2
     # via elmo_geo (pyproject.toml)
 sentinelsat==1.2.1
     # via elmo_geo (pyproject.toml)
-shapely==2.0.3
+shapely==2.0.4
     # via
     #   apache-sedona
-    #   elmo_geo (pyproject.toml)
     #   geopandas
     #   osdatahub
     #   osmnx
-shellingham==1.5.4
-    # via typer
 six==1.16.0
     # via
-    #   asttokens
-    #   databricks-cli
-    #   esridump
     #   fiona
+    #   patsy
     #   python-dateutil
-smmap==5.0.1
-    # via gitdb
 snuggs==1.4.7
     # via rasterio
 soupsieve==2.5
     # via beautifulsoup4
-sqlparse==0.4.4
-    # via mlflow-skinny
-stack-data==0.6.3
-    # via ipython
-tabulate==0.9.0
-    # via databricks-cli
-tenacity==8.2.3
-    # via dbx
-text-unidecode==1.3
-    # via python-slugify
-threadpoolctl==3.3.0
+statsmodels==0.14.2
+    # via elmo_geo (pyproject.toml)
+threadpoolctl==3.5.0
     # via scikit-learn
 tomli==2.0.1
     # via
     #   build
     #   pip-tools
-    #   pyproject-hooks
     #   pytest
-tornado==6.4
-    # via
-    #   ipykernel
-    #   jupyter-client
 tqdm==4.65.2
     # via
     #   osdatahub
     #   sentinelsat
-traitlets==5.14.1
-    # via
-    #   comm
-    #   ipykernel
-    #   ipython
-    #   ipywidgets
-    #   jupyter-client
-    #   jupyter-core
-    #   matplotlib-inline
 typeguard==2.13.3
     # via osdatahub
-typer[all]==0.7.0
-    # via dbx
-types-python-dateutil==2.8.19.20240106
-    # via arrow
-typing-extensions==4.9.0
-    # via
-    #   pydantic
-    #   pydantic-core
-urllib3==1.26.18
-    # via
-    #   databricks-cli
-    #   requests
-watchdog==4.0.0
-    # via dbx
-wcwidth==0.2.13
-    # via prompt-toolkit
-wheel==0.42.0
+urllib3==2.2.1
+    # via requests
+wheel==0.43.0
     # via pip-tools
-widgetsnbextension==4.0.10
-    # via ipywidgets
-xarray==2023.1.0
+xarray==2024.3.0
+    # via rioxarray
+xyzservices==2024.4.0
     # via
-    #   elmo_geo (pyproject.toml)
-    #   rioxarray
-xyzservices==2023.10.1
-    # via contextily
-yarl==1.9.4
-    # via aiohttp
-zipp==3.17.0
-    # via importlib-metadata
+    #   contextily
+    #   folium
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 affine==2.4.0
     # via rasterio
+annotated-types==0.7.0
+    # via pydantic
 apache-sedona==1.4.1
     # via elmo_geo (pyproject.toml)
 attrs==23.2.0
@@ -178,6 +180,10 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
+pydantic==2.7.3
+    # via elmo_geo (pyproject.toml)
+pydantic-core==2.18.4
+    # via pydantic
 pygments==2.18.0
     # via rich
 pyogrio==0.8.0
@@ -196,7 +202,7 @@ pyproject-hooks==1.1.0
     #   pip-tools
 pyspark==3.3.2
     # via elmo_geo (pyproject.toml)
-pytest==8.2.1
+pytest==8.2.2
     # via elmo_geo (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
@@ -267,6 +273,10 @@ tqdm==4.65.2
     #   sentinelsat
 typeguard==2.13.3
     # via osdatahub
+typing-extensions==4.12.1
+    # via
+    #   pydantic
+    #   pydantic-core
 urllib3==2.2.1
     # via requests
 wheel==0.43.0


### PR DESCRIPTION
Many of the dependencies listed in pyproject.toml were either; dependencies of another (potentially causing conflicts), or not required in the codebase.
Some of the dependencies are used by old tools, and are unlikely to be required in future.  This should be removed as the tool is updated.

I did a find "import " to find all dependencies, none have been omitted.
I am also aware of some optional silent dependencies like pyogrio being used by geopandas.
I'm pretty confident I captured everything, but I'm welcome to additions.